### PR TITLE
Modernize GitHub profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,148 +1,111 @@
 <div align="center">
 
-# 👋 Welcome to my GitHub profile!
+# Hey, I'm Alex Popa 👋
 
-<img src="https://github.com/alexandrupetrut/alexandrupetrut/blob/main/1610444347020.jpg" width="200" style="border-radius: 50%; margin: 20px 0;">
+### Software Architect · .NET / Azure · AI-enabled platforms
 
-### Software Architect & AI Integration Specialist
+I design maintainable backend, cloud, and product systems that turn messy business workflows into secure, observable, production-ready platforms.
 
----
-
-</div>
-
-## 🚀 About Me
-
-🏢 **I'm [Alex](https://www.linkedin.com/in/petrut-alex/)**, a **Software Architect** at **Enterprise Nation** from Bucharest, Romania
-
-� Currently **revamping platform systems** and **integrating AI solutions** to bring enterprise platforms to the next level
-
-⚡ Specializing in **AI-driven architecture design** and **intelligent automation workflows**
-
-🤖 Passionate about **cutting-edge AI technologies** and **enterprise-scale system modernization**
-
-## 🎯 Mission & Focus
-
-> **Transform traditional enterprise platforms through innovative AI integration and scalable architecture**
-
-**Current Focus Areas:**
-- 🏗️ **Platform Architecture** - Modern, scalable system design
-- 🤖 **AI/ML Integration** - Intelligent automation solutions  
-- 🔄 **Workflow Automation** - Streamlined business processes
-- 🏢 **Enterprise Solutions** - Large-scale system modernization
-
----
-
-## 🤖 AI & Machine Learning Stack
-
-<div align="center">
-
-### 🧠 AI Frameworks & Orchestration
-![LangChain](https://img.shields.io/badge/LangChain-1C3C3C?style=for-the-badge&logo=langchain&logoColor=white)
-![Pydantic AI](https://img.shields.io/badge/Pydantic_AI-092749?style=for-the-badge&logo=pydantic&logoColor=white)
-![Semantic Kernel](https://img.shields.io/badge/Semantic_Kernel-5C2D91?style=for-the-badge&logo=microsoft&logoColor=white)
-
-### ⚙️ Workflow Automation & Integration
-![N8N](https://img.shields.io/badge/N8N-EA4B71?style=for-the-badge&logo=n8n&logoColor=white)
-![Crawl4AI](https://img.shields.io/badge/Crawl4AI-FF6B6B?style=for-the-badge&logo=spider&logoColor=white)
-
-### 📊 Monitoring & Observability
-![LangFuse](https://img.shields.io/badge/LangFuse-7C3AED?style=for-the-badge&logo=chainlink&logoColor=white)
-![LogFire](https://img.shields.io/badge/LogFire-FF4500?style=for-the-badge&logo=fire&logoColor=white)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-Alex%20Popa-0A66C2?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/petrut-alex/)
+[![GitHub](https://img.shields.io/badge/GitHub-alex--enterprisenation-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/alex-enterprisenation)
+[![Location](https://img.shields.io/badge/Bucharest-Romania-1f6feb?style=flat-square)](#)
 
 </div>
 
 ---
 
-## �️ Core Technologies & Architecture
+## What I build
+
+- **AI-enabled business platforms** — RAG, agents, scoring pipelines, workflow automation, evaluation loops, and human review flows.
+- **Cloud-native backend systems** — .NET APIs, Azure services, SQL/Cosmos data models, event-driven integrations, and audit-friendly architecture.
+- **Modern SaaS foundations** — tenancy, roles, usage limits, secure auth, observability, operational dashboards, and cost-aware infrastructure.
+- **Product-minded architecture** — connecting backend quality with UX loops, analytics, business value, and maintainable delivery.
+
+## Current focus
+
+- Turning lead and business-signal workflows into practical AI-assisted products.
+- Modernising platform architecture across backend, frontend, data, and cloud boundaries.
+- Improving traceability, usage analytics, and observability so systems are easier to operate and evolve.
+- Exploring 3D game systems, AI-assisted tooling, and creative product ideas on the side.
+
+---
+
+## Core stack
 
 <div align="center">
 
-### 💻 Programming Languages
-![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
-![C#](https://img.shields.io/badge/C%23-239120.svg?style=for-the-badge&logo=c-sharp&logoColor=white)
-![Java](https://img.shields.io/badge/Java-ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white)
-![C](https://img.shields.io/badge/C-00599C.svg?style=for-the-badge&logo=c&logoColor=white)
+### Backend & architecture
 
-### 🌐 Web Technologies & Frameworks
-![JavaScript](https://img.shields.io/badge/JavaScript-323330.svg?style=for-the-badge&logo=javascript&logoColor=F7DF1E)
-![TypeScript](https://img.shields.io/badge/TypeScript-007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
-![Node.js](https://img.shields.io/badge/Node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white)
-![React](https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB)
-![Angular](https://img.shields.io/badge/Angular-DD0031.svg?style=for-the-badge&logo=angular&logoColor=white)
+![.NET](https://img.shields.io/badge/.NET-512BD4?style=flat-square&logo=dotnet&logoColor=white)
+![C#](https://img.shields.io/badge/C%23-239120?style=flat-square&logo=csharp&logoColor=white)
+![ASP.NET Core](https://img.shields.io/badge/ASP.NET%20Core-512BD4?style=flat-square&logo=dotnet&logoColor=white)
+![Domain Driven Design](https://img.shields.io/badge/DDD-Clean%20Boundaries-2ea44f?style=flat-square)
+![XUnit](https://img.shields.io/badge/Tests-xUnit%20%7C%20FakeItEasy%20%7C%20FluentAssertions-6f42c1?style=flat-square)
 
-### 🗄️ Enterprise Data Solutions
-![Oracle](https://img.shields.io/badge/Oracle-F00000.svg?style=for-the-badge&logo=oracle&logoColor=white)
-![SQL Server](https://img.shields.io/badge/Microsoft_SQL_Server-CC2927?style=for-the-badge&logo=microsoft-sql-server&logoColor=white)
-![SQLite](https://img.shields.io/badge/SQLite-07405e.svg?style=for-the-badge&logo=sqlite&logoColor=white)
-![GraphQL](https://img.shields.io/badge/GraphQL-E10098?style=for-the-badge&logo=graphql&logoColor=white)
-![Redis](https://img.shields.io/badge/Redis-DD0031.svg?style=for-the-badge&logo=redis&logoColor=white)
-![Elasticsearch](https://img.shields.io/badge/Elasticsearch-005571?style=for-the-badge&logo=elasticsearch&logoColor=white)
+### Cloud, data & AI
 
-### ☁️ Cloud & DevOps Infrastructure
-![Azure](https://img.shields.io/badge/Azure-0072C6.svg?style=for-the-badge&logo=microsoftazure&logoColor=white)
-![Google Cloud](https://img.shields.io/badge/Google_Cloud-4285F4.svg?style=for-the-badge&logo=google-cloud&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-0db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)
-![Kubernetes](https://img.shields.io/badge/Kubernetes-326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white)
+![Azure](https://img.shields.io/badge/Azure-0078D4?style=flat-square&logo=microsoftazure&logoColor=white)
+![Azure AI](https://img.shields.io/badge/Azure%20AI-0078D4?style=flat-square&logo=microsoftazure&logoColor=white)
+![SQL Server](https://img.shields.io/badge/SQL%20Server-CC2927?style=flat-square&logo=microsoftsqlserver&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?style=flat-square&logo=postgresql&logoColor=white)
+![Cosmos DB](https://img.shields.io/badge/Cosmos%20DB-0078D4?style=flat-square&logo=azurecosmosdb&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white)
 
-### 🔧 Development & Collaboration Tools
-![GitHub](https://img.shields.io/badge/GitHub-121011.svg?style=for-the-badge&logo=github&logoColor=white)
-![GitLab](https://img.shields.io/badge/GitLab-181717.svg?style=for-the-badge&logo=gitlab&logoColor=white)
-![Bitbucket](https://img.shields.io/badge/Bitbucket-0047B3.svg?style=for-the-badge&logo=bitbucket&logoColor=white)
-![Jira](https://img.shields.io/badge/Jira-0A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white)
+### Frontend & product delivery
 
-### 🎮 Game Development (Side Projects)
-![Unreal Engine](https://img.shields.io/badge/Unreal_Engine-313131.svg?style=for-the-badge&logo=unreal-engine&logoColor=white)
-![Unity](https://img.shields.io/badge/Unity-000000.svg?style=for-the-badge&logo=unity&logoColor=white)
-![Blender](https://img.shields.io/badge/Blender-F5792A.svg?style=for-the-badge&logo=blender&logoColor=white)
-![GIMP](https://img.shields.io/badge/GIMP-657D8B?style=for-the-badge&logo=gimp&logoColor=FFFFFF)
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)
+![Next.js](https://img.shields.io/badge/Next.js-000000?style=flat-square&logo=nextdotjs&logoColor=white)
+![React](https://img.shields.io/badge/React-61DAFB?style=flat-square&logo=react&logoColor=black)
+![GitHub Actions](https://img.shields.io/badge/GitHub%20Actions-2088FF?style=flat-square&logo=githubactions&logoColor=white)
+![Azure DevOps](https://img.shields.io/badge/Azure%20DevOps-0078D7?style=flat-square&logo=azuredevops&logoColor=white)
 
 </div>
 
 ---
 
-## 📈 GitHub Statistics
+## How I like to build
+
+```csharp
+public sealed record EngineeringStyle(
+    string Architecture,
+    string Delivery,
+    string Quality,
+    string Security,
+    string Observability);
+
+var alex = new EngineeringStyle(
+    Architecture: "Clean boundaries, DDD where useful, pragmatic modularity",
+    Delivery: "Small slices, visible value, production-first thinking",
+    Quality: "Readable code, focused tests, maintainable abstractions",
+    Security: "Least privilege, validation, safe defaults, audit trails",
+    Observability: "Logs, traces, metrics, correlation IDs, useful dashboards");
+```
+
+---
+
+## Engineering principles
+
+- **Make the business flow visible** before over-engineering the solution.
+- **Prefer boring, reliable architecture** until complexity proves it deserves a place.
+- **Design for humans in the loop** when AI confidence, review, or accountability matters.
+- **Treat observability as a feature**, not a cleanup task.
+- **Keep systems explainable** for developers, product teams, and stakeholders.
+
+---
+
+## GitHub snapshot
 
 <div align="center">
 
-<img width="48%" src="https://github-readme-stats.vercel.app/api?username=alex-enterprisenation&show_icons=true&theme=tokyonight&count_private=true&hide_border=true&bg_color=0d1117" alt="GitHub Stats" />
-<img width="48%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=alex-enterprisenation&theme=tokyonight&langs_count=8&layout=compact&hide_border=true&bg_color=0d1117&hide=html,css" alt="Top Languages" />
-
-<img width="70%" src="https://github-readme-streak-stats.herokuapp.com/?user=alex-enterprisenation&theme=tokyonight&hide_border=true&background=0d1117" alt="GitHub Streak" />
+<img height="165" src="https://github-readme-stats.vercel.app/api?username=alex-enterprisenation&show_icons=true&theme=transparent&hide_border=true&rank_icon=github" alt="Alex's GitHub stats" />
+<img height="165" src="https://github-readme-stats.vercel.app/api/top-langs/?username=alex-enterprisenation&layout=compact&theme=transparent&hide_border=true&hide=html,css" alt="Alex's top languages" />
 
 </div>
 
 ---
 
-## 🌟 Current Enterprise Nation Initiatives
-
 <div align="center">
 
-### **Transforming Enterprise Nation's Platform Ecosystem**
-
-</div>
-
-🏗️ **Platform Architecture Modernization**  
-*Redesigning core systems for enhanced scalability and performance*
-
-🤖 **AI Integration & Intelligence**  
-*Implementing cutting-edge automation and ML-driven features*
-
-🔄 **Advanced Workflow Orchestration**  
-*Building sophisticated automation pipelines with N8N and custom solutions*
-
-📊 **Comprehensive Observability**  
-*Ensuring system reliability through advanced logging and analytics*
-
-⚡ **Performance & Efficiency Optimization**  
-*Elevating enterprise platforms to unprecedented levels of efficiency*
-
----
-
-<div align="center">
-
-### 💫 *"Building the future of enterprise platforms, one AI integration at a time"* 💫
-
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/petrut-alex/)
-[![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/alex-enterprisenation)
+### Building practical AI + cloud systems that are useful, secure, and maintainable.
 
 </div>


### PR DESCRIPTION
## Summary

Refreshes the profile README with a cleaner, more modern GitHub profile layout.

## Changes

- Replaces the generic intro with a sharper Software Architect / .NET / Azure / AI positioning
- Reduces the badge wall into focused stack groups
- Removes noisy/less relevant sections and broken-looking legacy characters
- Keeps GitHub stats, but makes them visually lighter
- Adds a short C# personality block to make the profile feel more personal
- Adds clearer current focus and engineering principles sections

## Notes

This keeps the profile professional and public-safe: it references AI-enabled business platforms and lead/business-signal workflows without exposing internal implementation details.